### PR TITLE
Adds existing certificate to route after redeployment of a service

### DIFF
--- a/libexec/get_certificate
+++ b/libexec/get_certificate
@@ -88,5 +88,5 @@ else
     setup_well_known_route
     trap cleanup_well_known_route EXIT
     get_new_certificate "$DOMAINNAME"
-    add_certificate_to_route "$DOMAINNAME" "$SELFLINK"
 fi
+add_certificate_to_route "$DOMAINNAME" "$SELFLINK"


### PR DESCRIPTION
This way, an existing certificate is also added to a route if the corresponding service is redeployed.